### PR TITLE
Update calc PHPDoc

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -106,7 +106,7 @@ function wp_parse_args_r( &$a, $b ) {
  * @param 	int 	$decimals
  * @param 	int 	$precision
  *
- * @return 	array
+ * @return 	int|float|false
  */
 function calc( $number1, $action, $number2, $round = false, $decimals = 0, $precision = 10 ) {
     static $bc;


### PR DESCRIPTION
## Summary
- correct return type hint for calc()

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_685adbda85008325a3d0a9734d81b68b