### PR TITLE
Fix recursive array_flatten

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -220,7 +220,7 @@ function array_flatten( array $array = [] ): array {
         }
 
         if ( is_array( $element ) ) {
-            array_push( $result, ...flatten( $element ) );
+            array_push( $result, ...array_flatten( $element ) );
         } else {
             $result[] = $element;
         }


### PR DESCRIPTION
## Summary
- use `array_flatten()` recursively instead of an undefined `flatten()`

## Testing
- `npm run test:unit` *(fails: `wp-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_685adbd26c888325a40fc1f7503a9cf8